### PR TITLE
fix: remove extra div

### DIFF
--- a/6-grupos_y_canales.md
+++ b/6-grupos_y_canales.md
@@ -271,8 +271,6 @@ Grupo de Compra y Venta de artículos
 
 </div>
 
-</div>
-
 
 <div class="grupo">
 # Otros links de interes


### PR DESCRIPTION
# Problema

Había un selector /div extra en la pagina web del capitulo

![image](https://user-images.githubusercontent.com/26115793/111824214-aa79ab00-88c4-11eb-87a4-71c11f360575.png)


## Solución

- Remover el selector sobrante
